### PR TITLE
Fix static files in nginx.conf

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -4,7 +4,7 @@ location __PATH__/ {
 }
 
 location __PATH__/static/ {
-  alias __INSTALL_DIR__/sources/static/;
+  alias __INSTALL_DIR__/static/;
 }
 
 location @__NAME__ {


### PR DESCRIPTION
Après une install fraîche sur un Yunohost 11.2.11.2 les fichiers statics ne sont pas accessibles et le site inutilisable.

Ce commit corrige le problème me semble-t-il (le répertoire créé par la commande collectstatic est /var/www/compteur_du_gase/static).

@Salamandar ça te semble correct ?